### PR TITLE
Bug/remove deprecated crypto endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,3 +41,9 @@ BREAKING
 1.1.0
   - Adding batch quote support
   - Updating jest to 22.0.4
+
+1.1.1
+
+BREAKING
+  - Removing crypto daily, weekly, and monthly data endpoints, due to dropped
+    support from AV.

--- a/README.md
+++ b/README.md
@@ -87,9 +87,6 @@ alpha.forex.rate(from_currency, to_currency)
 See [Alpha Vantage](https://www.alphavantage.co/documentation/#digital-currency) for the parameters.
 ```javascript
 alpha.crypto.intraday(symbol, market)
-alpha.crypto.daily(symbol, market)
-alpha.crypto.weekly(symbol, market)
-alpha.crypto.monthly(symbol, market)
 ```
 
 ## Technicals

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -19,9 +19,6 @@ module.exports = config => {
     });
 
   return {
-    intraday: series('DIGITAL_CURRENCY_INTRADAY'),
-    daily: series('DIGITAL_CURRENCY_DAILY'),
-    weekly: series('DIGITAL_CURRENCY_WEEKLY'),
-    monthly: series('DIGITAL_CURRENCY_MONTHLY')
+    intraday: series('DIGITAL_CURRENCY_INTRADAY')
   };
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alphavantage",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A simple interface to the Alpha Vantage API.",
   "main": "index.js",
   "directories": {

--- a/test/crypto.js
+++ b/test/crypto.js
@@ -15,33 +15,3 @@ test(`intraday crypto works`, () => {
       expect(data['Time Series (Digital Currency Intraday)']).toBeDefined();
     });
 });
-
-test(`daily data works`, () => {
-  expect.assertions(2);
-  return delay(TIME)
-    .then(() => alpha.crypto.daily('btc', 'usd'))
-    .then(data => {
-      expect(data['Meta Data']).toBeDefined();
-      expect(data['Time Series (Digital Currency Daily)']).toBeDefined();
-    });
-});
-
-test(`weekly data works`, () => {
-  expect.assertions(2);
-  return delay(TIME)
-    .then(() => alpha.crypto.weekly('btc', 'usd'))
-    .then(data => {
-      expect(data['Meta Data']).toBeDefined();
-      expect(data['Time Series (Digital Currency Weekly)']).toBeDefined();
-    });
-});
-
-test(`monthly data works`, () => {
-  expect.assertions(2);
-  return delay(TIME)
-    .then(() => alpha.crypto.monthly('btc', 'usd'))
-    .then(data => {
-      expect(data['Meta Data']).toBeDefined();
-      expect(data['Time Series (Digital Currency Monthly)']).toBeDefined();
-    });
-});


### PR DESCRIPTION
Removing crypto daily, weekly, and monthly data endpoints due to dropped support from AV.

Pending AV confirmation to removed support before merging.