### PR TITLE
Ammends SearchStocks Type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -80,7 +80,7 @@ declare function alpha(config?: {
       interval?: string
     ) => Promise<T>;
     quote: (symbol: string, outputsize?: string, datatype?: string, interval?: string) => Promise<RawStockQuote>;
-    search: (keywords: string) => RawStockSearch;
+    search: (keywords: string) => Promise<RawStockSearch>;
   };
 
   forex: {


### PR DESCRIPTION
## Context
`search` Endpoint returns a Promise but declared as `RawStockSearch ` instead. According to 

## What was done?
According to `search` tests, used as an async call, it's clear the Endpoint returns. a Promise.
https://github.com/zackurben/alphavantage/blob/master/test/data.js#L94
