### PR TITLE
fix: export typescript interfaces

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -244,7 +244,7 @@ declare namespace alpha {
   // Polished
 
   // https://www.alphavantage.co/documentation/#latestprice
-  interface StockQuote {
+  export interface StockQuote {
     data: {
       symbol: string;
       open: string;
@@ -260,7 +260,7 @@ declare namespace alpha {
   }
 
   // https://www.alphavantage.co/documentation/#dailyadj
-  interface StockDailyAdjusted {
+  export interface StockDailyAdjusted {
     meta: {
       information: string;
       symbol: string;
@@ -285,7 +285,7 @@ declare namespace alpha {
   }
 
   // https://www.alphavantage.co/documentation/#symbolsearch
-  interface StockSearch {
+  export interface StockSearch {
     bestMatches: {
       [index: string]:
         | {


### PR DESCRIPTION
exports the typescript interfaces for polished data from the alpha namespace, so they
can be used when imported as an es module.

for example:
```typescript
import Alphavantage from "alphavantage"
const alpha = Alphavantage({key: 'api_key'});

// ...
const polishedData = alpha.util.polish<Alphavantage.StockQuote>(rawData);
```

closes zackurben/alphavantage#196