### PR TITLE
Fix ISO date conversion bug

### DIFF
--- a/lib/data.js
+++ b/lib/data.js
@@ -16,16 +16,18 @@ export default (config) => {
    * @returns {Function}
    *   A timeseries function to accept user data that returns a promise.
    */
-  const series = (fn) => (symbol, outputsize = 'compact', datatype = 'json', interval = '1min') => {
-    let params = {
-      symbol,
-      outputsize,
-      datatype
-    };
+  const series =
+    (fn) =>
+    (symbol, outputsize = 'compact', datatype = 'json', interval = '1min') => {
+      let params = {
+        symbol,
+        outputsize,
+        datatype
+      };
 
-    if (fn === 'TIME_SERIES_INTRADAY') params.interval = interval;
-    return util.fn(fn)(params);
-  };
+      if (fn === 'TIME_SERIES_INTRADAY') params.interval = interval;
+      return util.fn(fn)(params);
+    };
 
   /**
    * Util function to get the symbol search data.

--- a/lib/technical.js
+++ b/lib/technical.js
@@ -20,28 +20,30 @@ export default (config) => {
    * @param {String} fn
    *   The macdext-like function to use
    */
-  const MACDEXT_LIKE = (fn) => (
-    symbol,
-    interval,
-    series_type,
-    fastperiod = 12,
-    slowperiod = 26,
-    signalperiod = 9,
-    fastmatype,
-    slowmatype,
-    signalmatype
-  ) =>
-    util.fn(fn)({
+  const MACDEXT_LIKE =
+    (fn) =>
+    (
       symbol,
       interval,
       series_type,
-      fastperiod,
-      slowperiod,
-      signalperiod,
+      fastperiod = 12,
+      slowperiod = 26,
+      signalperiod = 9,
       fastmatype,
       slowmatype,
       signalmatype
-    });
+    ) =>
+      util.fn(fn)({
+        symbol,
+        interval,
+        series_type,
+        fastperiod,
+        slowperiod,
+        signalperiod,
+        fastmatype,
+        slowmatype,
+        signalmatype
+      });
 
   /**
    * A generic function generator for apo-like technicals.

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,11 +1,13 @@
 'use strict';
 
 import fetch from 'cross-fetch';
+import { DateTime } from "luxon";
 
 /**
  * Time stamp regex that AlphaVantage uses.
  */
 const timestamp = /[0-9]{4}-[0-9]{2}-[0-9]{2}( [0-9]{2}:[0-9]{2}:[0-9]{2})?/g;
+const timestampFormat = "yyyy-MM-dd HH:mm:ss";
 
 /**
  * Price regex for target markets in target currency.
@@ -240,6 +242,19 @@ export default (config) => {
    *   Normalized data.
    */
   const polish = (data) => {
+    
+    let timezone
+    if (data["Meta Data"]?.["6. Time Zone"]) {
+      timezone = data["Meta Data"]["6. Time Zone"];
+    } else {
+      timezone = "UTC"
+    }
+
+    return walkRawData(data, timezone)
+
+  };
+
+  const walkRawData = (data, timezone) => {
     // If this is not an object, dont recurse.
     if (!data || typeof data !== 'object') {
       return data;
@@ -250,37 +265,42 @@ export default (config) => {
     Object.keys(data).forEach((key) => {
       key = key.toString();
 
-      // If the key is a date time string, convert it to an iso timestamp.
+      // If the key is a date time string, convert it to a localised timestamp using the timezone, if provided.
       if (timestamp.test(key)) {
-        clean[new Date(key).toISOString()] = polish(data[key]);
+        var date = DateTime.fromFormat(key, timestampFormat, { zone: timezone })
+
+        if (!date.isValid) // invalid timezone
+          date = DateTime.fromFormat(key, timestampFormat)
+
+        clean[date.toISO()] = walkRawData(data[key], timezone);
         return;
       }
 
       // Rekey the crypto market open currency.
       if (cryptoMarketOpen.test(key)) {
-        clean['market_open'] = polish(data[key]);
+        clean['market_open'] = walkRawData(data[key], timezone);
         return;
       }
 
       // Rekey the crypto market high currency.
       if (cryptoMarketHigh.test(key)) {
-        clean['market_high'] = polish(data[key]);
+        clean['market_high'] = walkRawData(data[key], timezone);
         return;
       }
 
       // Rekey the crypto market low currency.
       if (cryptoMarketLow.test(key)) {
-        clean['market_low'] = polish(data[key]);
+        clean['market_low'] = walkRawData(data[key], timezone);
         return;
       }
 
       // Rekey the crypto market close currency.
       if (cryptoMarketClose.test(key)) {
-        clean['market_close'] = polish(data[key]);
+        clean['market_close'] = walkRawData(data[key], timezone);
         return;
       }
 
-      clean[keys[key] || key] = polish(data[key]);
+      clean[keys[key] || key] = walkRawData(data[key], timezone);
     });
 
     return clean;

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "node": ">=6.0.0"
   },
   "dependencies": {
-    "cross-fetch": "^3.0.6"
+    "cross-fetch": "^3.0.6",
+    "luxon": "^3.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.15.8",


### PR DESCRIPTION
Fixes the ISO date conversion bug in #356 

The adjusted code, on polish, will first look for a value in `data["Meta Data"]?.["6. Time Zone"]` and pass it to the recursive function to polish the object.  If it can't find a value it will default to UTC, which could lead into the same bug as before, but in the absence of a time zone from AV we have to assume something reasonable.  I couldn't find a default timezone in the documentation.  If you prefer, this could be changed to default to US Eastern.

When the polish routine finds a timestamp in the data, it will apply the timezone using the `luxon` library: https://moment.github.io/luxon/#/zones